### PR TITLE
Added the ability to adjust preset categories

### DIFF
--- a/import-config.yaml
+++ b/import-config.yaml
@@ -8,6 +8,8 @@ categoryIcon:
   "Big Data": "increase"
   "Message Queueing": "blockchain"
   "Web Server": "ip"
+  "SDN": "router"
+  "AI": "role"
 appNameReplace:
   "elasticsearch-exporter": "Elasticsearch Exporter"
   "harbor": "Harbor"

--- a/import-config.yaml
+++ b/import-config.yaml
@@ -5,11 +5,12 @@ categoryIcon:
   "Networking": "router"
   "Storage": "storage"
   "Image Registry": "cdn"
-  "Big Data": "increase"
   "Message Queueing": "blockchain"
   "Web Server": "ip"
   "SDN": "router"
   "AI": "role"
+  "Editor": "coding"
+  "Scheduler": "column"
 appNameReplace:
   "elasticsearch-exporter": "Elasticsearch Exporter"
   "harbor": "Harbor"


### PR DESCRIPTION
### The content of this PR is as follows:

* ECPaaS App Store default categories can now be modified by modifying the `categoryIcon` field value in `import-config.yaml`.
* Added `SDN`, `AI`, `Editor` and `Scheduler` default categories.